### PR TITLE
Update Mockery to v1.3.1 minimum to fix PHP 7.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "laravel-zero/framework": "^7.0"
     },
     "require-dev": {
-        "mockery/mockery": "^1.0",
+        "mockery/mockery": "^1.3.1",
         "phpunit/phpunit": "^8.5"
     },
     "autoload": {


### PR DESCRIPTION
This fixes the Travis errors in #270, I think this was actually resolved in around `1.2.3` of Mockery, but worth updating to the latest anyway. 👍